### PR TITLE
Load vcs instead of package to ensure composer.json file readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,8 @@ Add the following on your `composer.json`
 "repositories": [
   ...
   {
-      "type": "package",
-      "package": {
-          "name": "chip/chip-sdk-php",
-          "version": "v1.0.0",
-          "source": {
-              "url": "git@github.com:CHIPAsia/chip-php-sdk.git",
-              "type": "git",
-              "reference": "v1.0.0"
-          },
-          "autoload": {
-              "classmap": [
-                  "lib/"
-              ]
-          }
-      }
+      "type": "vcs",
+      "url": "git@github.com:CHIPAsia/chip-php-sdk.git"
   }
 ],
 "require": {

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -4,27 +4,12 @@
   "require": {
       "chip/chip-sdk-php": "^1.0.0",
       "php": ">=7.2.0",
-      "guzzlehttp/guzzle": "^7.0",
-      "netresearch/jsonmapper": "^4.0"
   },
   "license": "MIT",
   "repositories": [
     {
-        "type": "package",
-        "package": {
-            "name": "chip/chip-sdk-php",
-            "version": "v1.0.0",
-            "source": {
-                "url": "git@github.com:CHIPAsia/chip-php-sdk.git",
-                "type": "git",
-                "reference": "v1.0.0"
-            },
-            "autoload": {
-                "classmap": [
-                    "lib/"
-                ]
-            }
-        }
+        "type": "vcs",
+        "url": "git@github.com:CHIPAsia/chip-php-sdk.git"
     }
   ]
 }


### PR DESCRIPTION
Alternative. Redeclare everything declared by composer.json

```
{
    "repositories": [
      {
        "type": "package",
        "package": {
            "name": "chip/chip-sdk-php",
            "version": "v1.0.0",
            "source": {
                "url": "git@github.com:CHIPAsia/chip-php-sdk.git",
                "type": "git",
                "reference": "v1.0.0"
            },
            "autoload": {
                "classmap": [
                    "lib/"
                ]
            },
            "require": {
              "guzzlehttp/guzzle": "^7.0",
              "netresearch/jsonmapper": "^4.0"
            }
        }
      }
    ],
    "require": {
      "chip/chip-sdk-php": "^1.0"
    }
}
```