### PR TITLE
Update BillingTemplateClientAddSubscriber.php

### DIFF
--- a/lib/Model/Billing/BillingTemplateClientAddSubscriber.php
+++ b/lib/Model/Billing/BillingTemplateClientAddSubscriber.php
@@ -5,10 +5,16 @@ namespace Chip\Model\Billing;
 class BillingTemplateClientAddSubscriber implements \JsonSerializable
 {
 
-  #BillingTemplateClient
+  /**
+  *
+  * @var \Chip\Model\Billing\BillingTemplateClient
+  */
   public $billing_template_client;
 
-  #Purchase
+  /**
+  *
+  * @var \Chip\Model\Purchase
+  */
   public $purchase;
 
   #[\ReturnTypeWillChange]

--- a/lib/Model/Billing/BillingTemplateClientAddSubscriber.php
+++ b/lib/Model/Billing/BillingTemplateClientAddSubscriber.php
@@ -5,16 +5,10 @@ namespace Chip\Model\Billing;
 class BillingTemplateClientAddSubscriber implements \JsonSerializable
 {
 
-  /**
-   *
-   * @var BillingTemplateClient
-   */
+  #BillingTemplateClient
   public $billing_template_client;
 
-  /**
-   *
-   * @var Purchase
-   */
+  #Purchase
   public $purchase;
 
   #[\ReturnTypeWillChange]


### PR DESCRIPTION
**Issue**
Fixes #11 

**Description**
This pull request resolves the following issue:
`"Class "\Chip\Model\Billing\Purchase" does not exist"`

**Testing**
 Tested the fix locally and verified that the error no longer occurs.